### PR TITLE
Adding a version check that fixes gutter icon issue in ST3

### DIFF
--- a/delphi_style_bookmarks.py
+++ b/delphi_style_bookmarks.py
@@ -5,7 +5,7 @@ markPreffix = "delphi_style_bookmark_"
 class SetDelphiBookmarkCommand(sublime_plugin.TextCommand):
    def run(self, edit, key):
 
-      icon = '../Delphi Style Bookmarks/icons/'+ str(key)
+      icon = '../Delphi Style Bookmarks/icons/'+str(key) if int(sublime.version()) < 3000 else 'Packages/Delphi Style Bookmarks/icons/'+str(key)+'.png'
 
       markId = markPreffix + str(key)
 


### PR DESCRIPTION
Because the plugin path has changed in ST3 the gutter icons could no longer be found. This fixes that issue and allow this plugin to work properly in ST3 when it is being installed in the proper "Packages" directory.
